### PR TITLE
Simplify API and use "state" to improve type-safety

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 use axum::{response::IntoResponse, routing::get, Json};
 use http::StatusCode;
 
-// OPTIONAL: use a type alias to avoid repeating your database type
+// Recommended: use a type alias to avoid repeating your database type
 type Tx = axum_sqlx_tx::Tx<sqlx::Sqlite>;
 
 #[tokio::main]
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .execute(&pool)
         .await?;
 
-    let (layer, state) = axum_sqlx_tx::Layer::new(pool.clone());
+    let (state, layer) = Tx::setup(pool);
 
     // Standard axum app setup
     let app = axum::Router::new()

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -19,11 +19,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .execute(&pool)
         .await?;
 
+    let (layer, state) = axum_sqlx_tx::Layer::new(pool.clone());
+
     // Standard axum app setup
     let app = axum::Router::new()
         .route("/numbers", get(list_numbers).post(generate_number))
         // Apply the Tx middleware
-        .layer(axum_sqlx_tx::Layer::new(pool.clone()));
+        .layer(layer)
+        // Add the Tx state
+        .with_state(state);
 
     let server = axum::Server::bind(&([0, 0, 0, 0], 0).into()).serve(app.into_make_service());
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use futures_core::future::BoxFuture;
 use http_body::{combinators::UnsyncBoxBody, Body};
 
-use crate::{tx::TxSlot, Error};
+use crate::{tx::TxSlot, Error, State};
 
 /// A [`tower_layer::Layer`] that enables the [`Tx`] extractor.
 ///
@@ -21,42 +21,46 @@ use crate::{tx::TxSlot, Error};
 /// [`Tx`]: crate::Tx
 /// [request extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 pub struct Layer<DB: sqlx::Database, E = Error> {
-    pool: sqlx::Pool<DB>,
+    state: State<DB>,
     _error: PhantomData<E>,
 }
 
 impl<DB: sqlx::Database> Layer<DB> {
-    /// Construct a new layer with the given `pool`.
+    /// Construct a new layer and [`State`] with the given `pool`.
     ///
     /// A connection will be obtained from the pool the first time a [`Tx`](crate::Tx) is extracted
     /// from a request.
     ///
     /// If you want to access the pool outside of a transaction, you should add it also with
-    /// [`axum::Extension`].
+    /// [`axum::Extension`] or as router state.
     ///
     /// To use a different type than [`Error`] to convert commit errors into responses, see
     /// [`new_with_error`](Self::new_with_error).
     ///
     /// [`axum::Extension`]: https://docs.rs/axum/latest/axum/extract/struct.Extension.html
-    pub fn new(pool: sqlx::Pool<DB>) -> Self {
+    pub fn new(pool: sqlx::Pool<DB>) -> (Self, State<DB>) {
         Self::new_with_error(pool)
     }
 
     /// Construct a new layer with a specific error type.
     ///
     /// See [`Layer::new`] for more information.
-    pub fn new_with_error<E>(pool: sqlx::Pool<DB>) -> Layer<DB, E> {
-        Layer {
-            pool,
-            _error: PhantomData,
-        }
+    pub fn new_with_error<E>(pool: sqlx::Pool<DB>) -> (Layer<DB, E>, State<DB>) {
+        let state = State::new(pool);
+        (
+            Layer {
+                state: state.clone(),
+                _error: PhantomData,
+            },
+            state,
+        )
     }
 }
 
 impl<DB: sqlx::Database, E> Clone for Layer<DB, E> {
     fn clone(&self) -> Self {
         Self {
-            pool: self.pool.clone(),
+            state: self.state.clone(),
             _error: self._error,
         }
     }
@@ -67,7 +71,7 @@ impl<DB: sqlx::Database, S, E> tower_layer::Layer<S> for Layer<DB, E> {
 
     fn layer(&self, inner: S) -> Self::Service {
         Service {
-            pool: self.pool.clone(),
+            state: self.state.clone(),
             inner,
             _error: self._error,
         }
@@ -78,7 +82,7 @@ impl<DB: sqlx::Database, S, E> tower_layer::Layer<S> for Layer<DB, E> {
 ///
 /// See [`Layer`] for more information.
 pub struct Service<DB: sqlx::Database, S, E = Error> {
-    pool: sqlx::Pool<DB>,
+    state: State<DB>,
     inner: S,
     _error: PhantomData<E>,
 }
@@ -87,7 +91,7 @@ pub struct Service<DB: sqlx::Database, S, E = Error> {
 impl<DB: sqlx::Database, S: Clone, E> Clone for Service<DB, S, E> {
     fn clone(&self) -> Self {
         Self {
-            pool: self.pool.clone(),
+            state: self.state.clone(),
             inner: self.inner.clone(),
             _error: self._error,
         }
@@ -119,7 +123,7 @@ where
     }
 
     fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
-        let transaction = TxSlot::bind(req.extensions_mut(), self.pool.clone());
+        let transaction = TxSlot::bind(req.extensions_mut(), self.state.clone());
 
         let res = self.inner.call(req);
 
@@ -147,9 +151,11 @@ mod tests {
     fn layer_compiles() {
         let pool: sqlx::Pool<sqlx::Sqlite> = todo!();
 
+        let (layer, _state) = Layer::new(pool);
+
         let app = axum::Router::new()
             .route("/", axum::routing::get(|| async { "hello" }))
-            .layer(Layer::new(pool));
+            .layer(layer);
 
         axum::Server::bind(todo!()).serve(app.into_make_service());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,60 @@ mod layer;
 mod slot;
 mod tx;
 
+use std::marker::PhantomData;
+
 pub use crate::{
     layer::{Layer, Service},
     tx::Tx,
 };
+
+/// Configuration for [`Tx`] extractors.
+///
+/// Use `Config` to configure and build the [`State`] and [`Layer`] supporting [`Tx`] extractors.
+///
+/// A new `Config` can be constructed using [`Tx::config`].
+///
+/// ```
+/// # async fn foo() {
+/// # let pool: sqlx::SqlitePool = todo!();
+/// type Tx = axum_sqlx_tx::Tx<sqlx::Sqlite>;
+///
+/// let config = Tx::config(pool);
+/// # }
+/// ```
+pub struct Config<DB: sqlx::Database, LayerError> {
+    pool: sqlx::Pool<DB>,
+    _layer_error: PhantomData<LayerError>,
+}
+
+impl<DB: sqlx::Database, LayerError> Config<DB, LayerError> {
+    fn new(pool: sqlx::Pool<DB>) -> Self {
+        Self {
+            pool,
+            _layer_error: PhantomData,
+        }
+    }
+
+    /// Change the layer error type.
+    ///
+    /// The [`Layer`] middleware can return an error if the transaction fails to commit after a
+    /// successful response.
+    pub fn layer_error<E>(self) -> Config<DB, E>
+    where
+        Error: Into<E>,
+    {
+        Config {
+            pool: self.pool,
+            _layer_error: PhantomData,
+        }
+    }
+
+    /// Create a [`State`] and [`Layer`] to enable the [`Tx`] extractor.
+    pub fn setup(self) -> (State<DB>, Layer<DB, LayerError>) {
+        let (layer, state) = Layer::new(self.pool);
+        (state, layer.with_error())
+    }
+}
 
 /// Application state that enables the [`Tx`] extractor.
 ///

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -4,7 +4,7 @@
 //! Conceptually, the `Slot<T>` is the "primary" owner of the value, and access can be leased to one
 //! other owner through an associated `Lease<T>`.
 //!
-//! It's implemented as a wrapper around an `Arc<Mutex<Option_>>>`, where the `Slot` `take`s the
+//! It's implemented as a wrapper around an `Arc<Mutex<Option<_>>>`, where the `Slot` `take`s the
 //! value from the `Option` on lease, and the `Lease` puts it back in on drop.
 //!
 //! Note that while this is **safe** to use across threads (it is `Send` + `Sync`), concurrently

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -88,7 +88,7 @@ impl<DB: sqlx::Database, E> Tx<DB, E> {
     /// let (state, layer) = Tx::setup(pool);
     /// # }
     /// ```
-    pub fn setup(pool: sqlx::Pool<DB>) -> (State<DB>, crate::Layer<DB>) {
+    pub fn setup(pool: sqlx::Pool<DB>) -> (State<DB>, crate::Layer<DB, Error>) {
         Config::new(pool).setup()
     }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -113,8 +113,8 @@ impl<DB: sqlx::Database, E> Tx<DB, E> {
     /// Explicitly commit the transaction.
     ///
     /// By default, the transaction will be committed when a successful response is returned
-    /// (specifically, when the [`Service`](crate::Service) middleware intercepts an HTTP `2XX`
-    /// response). This method allows the transaction to be committed explicitly.
+    /// (specifically, when the [`Service`](crate::Service) middleware intercepts an HTTP `2XX` or
+    /// `3XX` response). This method allows the transaction to be committed explicitly.
     ///
     /// **Note:** trying to use the `Tx` extractor again after calling `commit` will currently
     /// generate [`Error::OverlappingExtractors`] errors. This may change in future.


### PR DESCRIPTION
The upshot of this PR is that:

- `Tx` is the only type that needs to be handled directly (i.e. `use`d or otherwise named).
- `Tx`'s `FromRequestParts` implementation requires `axum_sqlx_tx::State`, which goes someway to making it harder to forget to supply the extractor's dependencies (it doesn't prevent compilation when `Layer` is forgotten, but the `setup` methods return `(State, Layer)` making it harder to miss).

---

- 0927aab **chore: doc typo**


- c9eccaf **feat!: introduce `State` to make `Tx` more type-safe**

  `Tx` now implements `FromRequestParts<State>`, meaning the `Router` must
  be provided an instance of `State` in order for it to compile.
  
  `State` can be constructed with `Layer::new`, which now returns a tuple
  of `Layer` and `State`. The idea behind constructing both in the same
  function is to make it harder to forget to add the `Layer`, however
  `Layer::new` is perhaps not the best place for it long-term.
  
  Ultimately this has the desired effect of making `Tx` more type-safe -
  applications that attempt to use `Tx` without providing `State` won't
  compile, and the API for obtaining `State` makes it harder to forget to
  add the `Layer`.
  
  BREAKING CHANGE: `Layer::new` now returns a `(Layer, State)` tuple. This
  can be consumed easily by destructuring assignment. `Tx` now requires
  `State` to be provided on `Router`s in order for the `Router` to be
  usable.

- 32a0a0f **feat: introduce `Tx::setup`, `Tx::config`, and `Config` APIs**

  This will centralise the configuration API and reduce the number of
  types that need to interacted with directly (i.e. `use`d) down to just
  `Tx`.

- e8f694e **refactor!: remove `Layer::new` and `Layer::new_with_error`**

  This leaves `Tx::{setup,config}` as the only entrypoints to the API.
  
  Error handling documentation was also rewritten.
  
  BREAKING CHANGE: `Layer::{new,new_with_error}` have been removed. Use
  `Tx::{setup,config}` instead.

- e2701a7 **refactor!: rationalise generic error type bounds**

  Required bounds are now present on more `impl` blocks to provide better
  diagnostics if error types are missing required traits.
  
  The `Layer` error type is now only required to implement
  `From<sqlx::Error>` (technically `sqlx::Error` is required to implement
  `Into<LayerError>` since this is more flexible).
  
  BREAKING CHANGE: The tighter bounds on `impl` blocks shouldn't break
  already working code, however the change to the `Layer` error type
  bounds will break error overrides that implement
  `From<axum_sqlx_tx::Error>` - this must be changed to
  `From<sqlx::Error>`.

- e896b5a **chore: doc fix**

