### PR TITLE
Small tidy ups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,5 @@ tower-service = "0.3"
 axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }
 axum = "0.6.4"
 hyper = "0.14.17"
-tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.12"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -11,8 +11,7 @@ type Tx = axum_sqlx_tx::Tx<sqlx::Sqlite>;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // You can use any sqlx::Pool
-    let db = tempfile::NamedTempFile::new()?;
-    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", db.path().display())).await?;
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
 
     // Create a table (in a real application you might run migrations)
     sqlx::query("CREATE TABLE IF NOT EXISTS numbers (number INT PRIMARY KEY);")


### PR DESCRIPTION
- 4a9a99c **refactor: use in-memory sqlite for tests and examples**

  This avoids having to manage temporary files, and lets us drop the
  `tempfile` dev dependency.

- 2e62b8c **refactor!: replace `sqlx_impls` macro with blanket impl**

  Less macros, less problems? This also makes the crate easier to use with
  other databases (e.g. custom ones).
  
  This could probably technically be a breaking change in some situations,
  e.g. if a specific implementation *was* provided for a custom
  `sqlx::Database` type.
  
  BREAKING CHANGE: The blanket impl will conflict with any explicit impls
  of `sqlx::Executor` on `Tx<_>`.

- f6f43db **refactor: convert `Tx` from a tuple struct**

  Named fields are generally a bit clearer for structs with multiple
  fields.
