### PR TITLE
Upgrade to sqlx 0.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,20 +7,7 @@ on:
 
 jobs:
   clippy:
-    strategy:
-      fail-fast: false
-      matrix:
-        db: ['', all-databases, mysql, postgres, sqlite]
-        db_any: ['', any]
-        runtime: [runtime-tokio-native-tls, runtime-tokio-rustls]
-        exclude:
-          # no-db w/ any doesn't make sense (sqlx won't compile)
-          - db: ''
-            db_any: any
-          # all-databases w/ any is redundant (all-databases enables any)
-          - db: all-databases
-            db_any: any
-    name: clippy (${{ matrix.runtime }}, ${{ matrix.db || 'no-db' }} ${{ matrix.db_any && 'w/ any' || 'w/o any' }})
+    name: clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +19,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features '${{ matrix.db }} ${{ matrix.db_any }} ${{ matrix.runtime }}' -- -D warnings
+          args: -- -D warnings
 
   doc:
     runs-on: ubuntu-latest
@@ -45,7 +32,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --features runtime-tokio-rustls,all-databases
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.8.0"
+version = "0.9.0"
 license = "MIT"
 repository = "https://github.com/digital-society-coop/axum-sqlx-tx/"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,6 @@ include = [
   "**/*.rs"
 ]
 
-[features]
-all-databases = ["any", "mysql", "postgres", "sqlite"]
-any = ["sqlx/any"]
-mysql = ["sqlx/mysql"]
-postgres = ["sqlx/postgres"]
-sqlite = ["sqlx/sqlite"]
-
-runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls"]
-runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]
-
-[package.metadata.docs.rs]
-features = ["all-databases", "runtime-tokio-rustls"]
-
 [dependencies]
 axum-core = "0.4"
 bytes = "1"
@@ -38,8 +25,8 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum-sqlx-tx = { path = ".", features = ["runtime-tokio-rustls", "sqlite"] }
 axum = "0.7.2"
 hyper = "1.0.1"
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures-core = "0.3"
 http = "1"
 http-body = "1"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
-sqlx = { version = "0.7", default-features = false }
+sqlx = { version = "0.8", default-features = false }
 thiserror = "1"
 tower-layer = "0.3"
 tower-service = "0.3"

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -232,10 +232,7 @@ where
         self,
         sql: &'q str,
         parameters: &'e [<Self::Database as sqlx::Database>::TypeInfo],
-    ) -> BoxFuture<
-        'e,
-        Result<<Self::Database as sqlx::database::HasStatement<'q>>::Statement, sqlx::Error>,
-    >
+    ) -> BoxFuture<'e, Result<<Self::Database as sqlx::Database>::Statement<'q>, sqlx::Error>>
     where
         'c: 'e,
     {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -427,8 +427,8 @@ async fn multi_db() {
 
 async fn insert_user(tx: &mut Tx, id: i32, name: &str) -> (i32, String) {
     let mut args = SqliteArguments::default();
-    args.add(id);
-    args.add(name);
+    args.add(id).unwrap();
+    args.add(name).unwrap();
     sqlx::query_as_with(
         r#"INSERT INTO users VALUES (?, ?) RETURNING id, name;"#,
         args,
@@ -486,11 +486,13 @@ where
     (pool, Response { status, body })
 }
 
-struct MyExtractorError(axum_sqlx_tx::Error);
+struct MyExtractorError {
+    _0: axum_sqlx_tx::Error,
+}
 
 impl From<axum_sqlx_tx::Error> for MyExtractorError {
     fn from(error: axum_sqlx_tx::Error) -> Self {
-        Self(error)
+        Self { _0: error }
     }
 }
 
@@ -500,11 +502,13 @@ impl IntoResponse for MyExtractorError {
     }
 }
 
-struct MyLayerError(sqlx::Error);
+struct MyLayerError {
+    _0: sqlx::Error,
+}
 
 impl From<sqlx::Error> for MyLayerError {
     fn from(error: sqlx::Error) -> Self {
-        Self(error)
+        Self { _0: error }
     }
 }
 


### PR DESCRIPTION
- 9a59857 **chore!: upgrade `sqlx`**

  BREAKING CHANGE: `sqlx` 0.7 is no longer supported.

- 437e260 **chore: fix lints**


- ed42671 **chore!: simplify features**

  The database-specific features haven't been required for a long time, and
  it's unnecessary to proxy `sqlx`'s features since the library can't
  really be useful without a direct dependency on `sqlx`.
  
  BREAKING CHANGE: all features have been removed. Configure
  database/runtime features directly on `sqlx`.

- ceaeda3 **chore: bump version**

