### PR TITLE
Upgrade axum to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-sqlx-tx"
 description = "Request-scoped SQLx transactions for axum"
-version = "0.9.0"
+version = "0.10.0"
 license = "MIT"
 repository = "https://github.com/digital-society-coop/axum-sqlx-tx/"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = [
 ]
 
 [dependencies]
-axum-core = "0.4"
+axum-core = "0.5"
 bytes = "1"
 futures-core = "0.3"
 http = "1"
@@ -25,8 +25,8 @@ tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum = "0.7.2"
+axum = "0.8.1"
 hyper = "1.0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
-tower = "0.4.12"
+tower = "0.5.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,8 @@
 /// #    .route("/", post(create_user))
 /// #    .layer(layer)
 /// #    .with_state(state);
-/// # axum::serve(todo!(), app);
+/// # let listener: tokio::net::TcpListener = todo!();
+/// # axum::serve(listener, app);
 /// # }
 /// # async fn create_user(mut tx: Tx, /* ... */) {
 /// #     /* ... */

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -130,6 +130,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use tokio::net::TcpListener;
+
     use crate::{Error, State};
 
     use super::Layer;
@@ -146,6 +148,7 @@ mod tests {
             .route("/", axum::routing::get(|| async { "hello" }))
             .layer(layer);
 
-        axum::serve(todo!(), app);
+        let listener: TcpListener = todo!();
+        axum::serve(listener, app);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //! #   .route("/", axum::routing::get(|tx: Tx| async move {}))
 //!     .layer(layer)
 //!     .with_state(state);
-//! # axum::serve(todo!(), app);
+//! # let listener: tokio::net::TcpListener = todo!();
+//! # axum::serve(listener, app);
 //! # }
 //! ```
 //!

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -63,7 +63,8 @@ use std::fmt::Debug;
 ///     .layer(layer1)
 ///     .layer(layer2)
 ///     .with_state(MyState { state1, state2 });
-/// # axum::serve(todo!(), app);
+/// # let listener: tokio::net::TcpListener = todo!();
+/// # axum::serve(listener, app);
 /// # }
 /// ```
 pub trait Marker: Debug + Send + Sized + 'static {


### PR DESCRIPTION
- 2d88ec1 **chore!: upgrade axum to 0.8**

  The only significant change is in the switch from `async_trait` to native
  async trait methods.
  
  BREAKING CHANGE: The crate is no longer compatible with axum @ 0.7. Don't
  upgrade the crate unless you want to upgrade axum as well!

- bf9a5e7 **chore: bump version**

